### PR TITLE
Load JAGEOCODER_ENDPOINT secret in CI pytest

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Run tests
         run: pytest
+        env:
+          JAGEOCODER_ENDPOINT: ${{ secrets.JAGEOCODER_ENDPOINT }}
 
   # Deploy jobs - only run on push to main/master
   deploy-map2csv:


### PR DESCRIPTION
Load JAGEOCODER_ENDPOINT from repository secrets when running pytest in the test-normalizer job to ensure tests have access to the endpoint.

https://claude.ai/code/session_WwXOR

# 変更の概要
- ここに変更の概要を記載してください

# 変更の背景
- ここに変更が必要となった背景を記載してください

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/poster-map/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました
